### PR TITLE
chore(deploy): add one-click caddy reverse-proxy deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ git fetch origin && git reset --hard origin/main
 docker compose down && docker compose up -d --build
 ```
 
+### 🌍 服务器一键部署（域名 + Caddy 自动反代）
+
+适用于 Linux 服务器（Debian/Ubuntu 可自动安装 Caddy）：
+
+```bash
+bash scripts/deploy-with-caddy.sh --domain your-domain.com --email you@example.com
+```
+
+部署完成后访问：
+
+- `https://your-domain.com`
+- `https://your-domain.com/admin/queues`
+
 ---
 
 ## 🚀 Quick Start
@@ -87,6 +100,19 @@ Visit [http://localhost:13000](http://localhost:13000) to get started!
 git fetch origin && git reset --hard origin/main
 docker compose down && docker compose up -d --build
 ```
+
+### 🌍 One-Click Server Deploy (Domain + Caddy Reverse Proxy)
+
+For Linux servers (Debian/Ubuntu can auto-install Caddy):
+
+```bash
+bash scripts/deploy-with-caddy.sh --domain your-domain.com --email you@example.com
+```
+
+After deployment:
+
+- `https://your-domain.com`
+- `https://your-domain.com/admin/queues`
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       MYSQL_DATABASE: waoowaoo
       MYSQL_ROOT_HOST: "%"
     ports:
-      - "13306:3306"
+      - "${MYSQL_BIND_IP:-127.0.0.1}:13306:3306"
     volumes:
       - mysql_data:/var/lib/mysql
     command:
@@ -28,7 +28,7 @@ services:
     container_name: waoowaoo-redis
     restart: unless-stopped
     ports:
-      - "16379:6379"
+      - "${REDIS_BIND_IP:-127.0.0.1}:16379:6379"
     volumes:
       - redis_data:/data
     command: ["redis-server", "--appendonly", "yes"]
@@ -46,50 +46,51 @@ services:
     restart: unless-stopped
     environment:
       # 数据库（指向容器内部 MySQL，用服务名 mysql 而非 localhost）
-      DATABASE_URL: "mysql://root:waoowaoo123@mysql:3306/waoowaoo"
+      DATABASE_URL: "${DATABASE_URL:-mysql://root:waoowaoo123@mysql:3306/waoowaoo}"
       # Redis（指向容器内部 Redis，用服务名 redis）
-      REDIS_HOST: redis
-      REDIS_PORT: "6379"
-      REDIS_USERNAME: ""
-      REDIS_PASSWORD: ""
-      REDIS_TLS: ""
+      REDIS_HOST: "${REDIS_HOST:-redis}"
+      REDIS_PORT: "${REDIS_PORT:-6379}"
+      REDIS_USERNAME: "${REDIS_USERNAME:-}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:-}"
+      REDIS_TLS: "${REDIS_TLS:-}"
       # 存储：默认本地存储
-      STORAGE_TYPE: local
+      STORAGE_TYPE: "${STORAGE_TYPE:-local}"
       # 认证
-      NEXTAUTH_URL: "http://localhost:3000"
-      NEXTAUTH_SECRET: "waoowaoo-default-secret-2026"
+      NEXTAUTH_URL: "${NEXTAUTH_URL:-http://localhost:13000}"
+      NEXTAUTH_SECRET: "${NEXTAUTH_SECRET:-waoowaoo-default-secret-2026}"
       # 内部密钥
-      CRON_SECRET: "waoowaoo-docker-cron-secret"
-      INTERNAL_TASK_TOKEN: "waoowaoo-docker-task-token"
-      API_ENCRYPTION_KEY: "waoowaoo-opensource-fixed-key-2026"
+      CRON_SECRET: "${CRON_SECRET:-waoowaoo-docker-cron-secret}"
+      INTERNAL_TASK_TOKEN: "${INTERNAL_TASK_TOKEN:-waoowaoo-docker-task-token}"
+      API_ENCRYPTION_KEY: "${API_ENCRYPTION_KEY:-waoowaoo-opensource-fixed-key-2026}"
+      INTERNAL_TASK_API_BASE_URL: "${INTERNAL_TASK_API_BASE_URL:-http://127.0.0.1:3000}"
       # Worker 配置
-      WATCHDOG_INTERVAL_MS: "30000"
-      TASK_HEARTBEAT_TIMEOUT_MS: "90000"
-      QUEUE_CONCURRENCY_IMAGE: "50"
-      QUEUE_CONCURRENCY_VIDEO: "50"
-      QUEUE_CONCURRENCY_VOICE: "20"
-      QUEUE_CONCURRENCY_TEXT: "50"
+      WATCHDOG_INTERVAL_MS: "${WATCHDOG_INTERVAL_MS:-30000}"
+      TASK_HEARTBEAT_TIMEOUT_MS: "${TASK_HEARTBEAT_TIMEOUT_MS:-90000}"
+      QUEUE_CONCURRENCY_IMAGE: "${QUEUE_CONCURRENCY_IMAGE:-50}"
+      QUEUE_CONCURRENCY_VIDEO: "${QUEUE_CONCURRENCY_VIDEO:-50}"
+      QUEUE_CONCURRENCY_VOICE: "${QUEUE_CONCURRENCY_VOICE:-20}"
+      QUEUE_CONCURRENCY_TEXT: "${QUEUE_CONCURRENCY_TEXT:-50}"
       # Bull Board
-      BULL_BOARD_HOST: "0.0.0.0"
-      BULL_BOARD_PORT: "3010"
-      BULL_BOARD_BASE_PATH: "/admin/queues"
-      BULL_BOARD_USER: ""
-      BULL_BOARD_PASSWORD: ""
+      BULL_BOARD_HOST: "${BULL_BOARD_HOST:-0.0.0.0}"
+      BULL_BOARD_PORT: "${BULL_BOARD_PORT:-3010}"
+      BULL_BOARD_BASE_PATH: "${BULL_BOARD_BASE_PATH:-/admin/queues}"
+      BULL_BOARD_USER: "${BULL_BOARD_USER:-}"
+      BULL_BOARD_PASSWORD: "${BULL_BOARD_PASSWORD:-}"
       # 日志
-      LOG_UNIFIED_ENABLED: "true"
-      LOG_LEVEL: "INFO"
-      LOG_FORMAT: "json"
-      LOG_DEBUG_ENABLED: "false"
-      LOG_AUDIT_ENABLED: "true"
-      LOG_SERVICE: "waoowaoo"
-      LOG_REDACT_KEYS: "password,token,apiKey,apikey,authorization,cookie,secret,access_token,refresh_token"
+      LOG_UNIFIED_ENABLED: "${LOG_UNIFIED_ENABLED:-true}"
+      LOG_LEVEL: "${LOG_LEVEL:-INFO}"
+      LOG_FORMAT: "${LOG_FORMAT:-json}"
+      LOG_DEBUG_ENABLED: "${LOG_DEBUG_ENABLED:-false}"
+      LOG_AUDIT_ENABLED: "${LOG_AUDIT_ENABLED:-true}"
+      LOG_SERVICE: "${LOG_SERVICE:-waoowaoo}"
+      LOG_REDACT_KEYS: "${LOG_REDACT_KEYS:-password,token,apiKey,apikey,authorization,cookie,secret,access_token,refresh_token}"
       # 计费
-      BILLING_MODE: "SHADOW"
+      BILLING_MODE: "${BILLING_MODE:-SHADOW}"
       # 流式
-      LLM_STREAM_EPHEMERAL_ENABLED: "true"
+      LLM_STREAM_EPHEMERAL_ENABLED: "${LLM_STREAM_EPHEMERAL_ENABLED:-true}"
     ports:
-      - "13000:3000"
-      - "13010:3010"
+      - "${APP_BIND_IP:-127.0.0.1}:13000:3000"
+      - "${APP_BIND_IP:-127.0.0.1}:13010:3010"
     volumes:
       - ./data:/app/data
       - ./docker-logs:/app/logs
@@ -118,4 +119,3 @@ services:
 volumes:
   mysql_data:
   redis_data:
-

--- a/scripts/deploy-with-caddy.sh
+++ b/scripts/deploy-with-caddy.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+DOMAIN=""
+EMAIL=""
+ENV_FILE="${PROJECT_DIR}/.env.deploy"
+CADDYFILE_PATH="/etc/caddy/Caddyfile"
+BULL_BOARD_USER=""
+BULL_BOARD_PASSWORD=""
+SKIP_BUILD=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/deploy-with-caddy.sh --domain your-domain.com [options]
+
+Options:
+  -d, --domain           Required. Domain used for public access.
+  -e, --email            Optional. Email for ACME notifications.
+      --env-file         Optional. Compose env file path (default: .env.deploy).
+      --bull-user        Optional. Bull Board basic auth username.
+      --bull-password    Optional. Bull Board basic auth password.
+      --skip-build       Optional. Start existing images without rebuilding.
+  -h, --help             Show this help.
+
+Notes:
+  1) Point the domain DNS A/AAAA record to this server before running.
+  2) Ensure ports 80 and 443 are reachable from the internet.
+  3) On Debian/Ubuntu, Caddy will be auto-installed if missing.
+EOF
+}
+
+log() {
+  printf '[deploy] %s\n' "$*"
+}
+
+fail() {
+  printf '[deploy][error] %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "${cmd}" >/dev/null 2>&1 || fail "Missing command: ${cmd}"
+}
+
+normalize_domain() {
+  local value="$1"
+  value="${value#http://}"
+  value="${value#https://}"
+  value="${value%%/*}"
+  printf '%s' "${value}"
+}
+
+generate_hex_secret() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+    return
+  fi
+  LC_ALL=C tr -dc 'a-f0-9' </dev/urandom | head -c 64
+}
+
+upsert_env() {
+  local key="$1"
+  local value="$2"
+  local file="$3"
+  local tmp
+  tmp="$(mktemp)"
+
+  awk -v k="${key}" -v v="${value}" '
+    BEGIN { updated = 0 }
+    $0 ~ ("^" k "=") {
+      if (updated == 0) {
+        print k "=" v
+        updated = 1
+      }
+      next
+    }
+    { print }
+    END {
+      if (updated == 0) {
+        print k "=" v
+      }
+    }
+  ' "${file}" > "${tmp}"
+
+  mv "${tmp}" "${file}"
+}
+
+set_if_missing_env() {
+  local key="$1"
+  local value="$2"
+  local file="$3"
+  if ! grep -q "^${key}=" "${file}" 2>/dev/null; then
+    printf '%s=%s\n' "${key}" "${value}" >> "${file}"
+  fi
+}
+
+install_caddy_if_needed() {
+  local sudo_cmd="$1"
+  if command -v caddy >/dev/null 2>&1; then
+    return
+  fi
+
+  if ! command -v apt-get >/dev/null 2>&1; then
+    fail "Caddy is not installed, and auto-install currently supports Debian/Ubuntu only."
+  fi
+
+  log "Caddy not found. Installing via apt."
+  ${sudo_cmd} apt-get update -y
+  ${sudo_cmd} apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl gnupg
+  ${sudo_cmd} install -m 0755 -d /etc/apt/keyrings
+  if [[ ! -f /etc/apt/keyrings/caddy-stable-archive-keyring.gpg ]]; then
+    curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key | ${sudo_cmd} gpg --dearmor -o /etc/apt/keyrings/caddy-stable-archive-keyring.gpg
+  fi
+  curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt | ${sudo_cmd} tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
+  ${sudo_cmd} apt-get update -y
+  ${sudo_cmd} apt-get install -y caddy
+}
+
+write_caddyfile() {
+  local domain="$1"
+  local email="$2"
+  local target="$3"
+
+  if [[ -n "${email}" ]]; then
+    cat > "${target}" <<EOF
+{
+    email ${email}
+}
+
+${domain} {
+    encode zstd gzip
+
+    @queues path /admin/queues*
+    handle @queues {
+        reverse_proxy 127.0.0.1:13010
+    }
+
+    handle {
+        reverse_proxy 127.0.0.1:13000
+    }
+}
+EOF
+    return
+  fi
+
+  cat > "${target}" <<EOF
+${domain} {
+    encode zstd gzip
+
+    @queues path /admin/queues*
+    handle @queues {
+        reverse_proxy 127.0.0.1:13010
+    }
+
+    handle {
+        reverse_proxy 127.0.0.1:13000
+    }
+}
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d|--domain)
+      [[ $# -ge 2 ]] || fail "Missing value for $1"
+      DOMAIN="$2"
+      shift 2
+      ;;
+    -e|--email)
+      [[ $# -ge 2 ]] || fail "Missing value for $1"
+      EMAIL="$2"
+      shift 2
+      ;;
+    --env-file)
+      [[ $# -ge 2 ]] || fail "Missing value for $1"
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --bull-user)
+      [[ $# -ge 2 ]] || fail "Missing value for $1"
+      BULL_BOARD_USER="$2"
+      shift 2
+      ;;
+    --bull-password)
+      [[ $# -ge 2 ]] || fail "Missing value for $1"
+      BULL_BOARD_PASSWORD="$2"
+      shift 2
+      ;;
+    --skip-build)
+      SKIP_BUILD=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown option: $1"
+      ;;
+  esac
+done
+
+if [[ -z "${DOMAIN}" ]]; then
+  read -r -p "Domain (example.com): " DOMAIN
+fi
+
+DOMAIN="$(normalize_domain "${DOMAIN}")"
+[[ -n "${DOMAIN}" ]] || fail "Domain cannot be empty."
+
+require_cmd docker
+docker compose version >/dev/null 2>&1 || fail "docker compose plugin is required."
+
+SUDO_CMD=""
+if [[ "${EUID}" -ne 0 ]]; then
+  require_cmd sudo
+  SUDO_CMD="sudo"
+fi
+
+install_caddy_if_needed "${SUDO_CMD}"
+
+mkdir -p "$(dirname "${ENV_FILE}")"
+touch "${ENV_FILE}"
+
+log "Preparing env file: ${ENV_FILE}"
+upsert_env "NEXTAUTH_URL" "https://${DOMAIN}" "${ENV_FILE}"
+upsert_env "APP_BIND_IP" "127.0.0.1" "${ENV_FILE}"
+upsert_env "MYSQL_BIND_IP" "127.0.0.1" "${ENV_FILE}"
+upsert_env "REDIS_BIND_IP" "127.0.0.1" "${ENV_FILE}"
+upsert_env "INTERNAL_TASK_API_BASE_URL" "http://127.0.0.1:3000" "${ENV_FILE}"
+
+set_if_missing_env "NEXTAUTH_SECRET" "$(generate_hex_secret)" "${ENV_FILE}"
+set_if_missing_env "CRON_SECRET" "$(generate_hex_secret)" "${ENV_FILE}"
+set_if_missing_env "INTERNAL_TASK_TOKEN" "$(generate_hex_secret)" "${ENV_FILE}"
+set_if_missing_env "API_ENCRYPTION_KEY" "$(generate_hex_secret)" "${ENV_FILE}"
+
+if [[ -z "${BULL_BOARD_USER}" ]]; then
+  BULL_BOARD_USER="admin"
+fi
+if [[ -z "${BULL_BOARD_PASSWORD}" ]]; then
+  BULL_BOARD_PASSWORD="$(generate_hex_secret)"
+fi
+upsert_env "BULL_BOARD_USER" "${BULL_BOARD_USER}" "${ENV_FILE}"
+upsert_env "BULL_BOARD_PASSWORD" "${BULL_BOARD_PASSWORD}" "${ENV_FILE}"
+
+log "Starting application stack"
+cd "${PROJECT_DIR}"
+if [[ "${SKIP_BUILD}" -eq 1 ]]; then
+  docker compose --env-file "${ENV_FILE}" up -d
+else
+  docker compose --env-file "${ENV_FILE}" up -d --build
+fi
+
+tmp_caddyfile="$(mktemp)"
+write_caddyfile "${DOMAIN}" "${EMAIL}" "${tmp_caddyfile}"
+
+if [[ -f "${CADDYFILE_PATH}" ]]; then
+  backup_path="${CADDYFILE_PATH}.bak.$(date +%Y%m%d%H%M%S)"
+  log "Backing up existing Caddyfile to ${backup_path}"
+  ${SUDO_CMD} cp "${CADDYFILE_PATH}" "${backup_path}"
+fi
+
+log "Applying Caddy reverse proxy config for ${DOMAIN}"
+${SUDO_CMD} mkdir -p "$(dirname "${CADDYFILE_PATH}")"
+${SUDO_CMD} cp "${tmp_caddyfile}" "${CADDYFILE_PATH}"
+rm -f "${tmp_caddyfile}"
+
+${SUDO_CMD} caddy validate --config "${CADDYFILE_PATH}"
+
+if command -v systemctl >/dev/null 2>&1; then
+  ${SUDO_CMD} systemctl enable --now caddy
+  ${SUDO_CMD} systemctl reload caddy
+  log "Caddy service reloaded."
+else
+  log "systemctl not found. Start Caddy manually with: caddy run --config ${CADDYFILE_PATH}"
+fi
+
+log "Deployment finished."
+printf '\n'
+printf 'App URL: https://%s\n' "${DOMAIN}"
+printf 'Bull Board: https://%s/admin/queues\n' "${DOMAIN}"
+printf 'Bull Board credentials: %s / %s\n' "${BULL_BOARD_USER}" "${BULL_BOARD_PASSWORD}"
+printf 'Env file: %s\n' "${ENV_FILE}"


### PR DESCRIPTION
## Summary

- What changed:
- Why:

## Architecture Plan Sync (Required)

- Master plan file: `/Users/earth/Desktop/waoowaoo/docs/architecture-unification-master-plan.md`
- [ ] I updated the phase status board (`✅/🔄/⏸/⚠️`) in the same PR.
- [ ] I recorded concrete file-level changes under the corresponding phase.
- [ ] I kept the plan date/current-context consistent with the code changes in this PR.

## Phase Status Delta (Required)

| Phase | Before | After | Evidence (file path) |
| --- | --- | --- | --- |
| e.g. Phase 1.2 | 🔄 | ✅ | `src/lib/query/task-target-overlay.ts` |

## Guardrails Checklist (Required)

- [ ] No compatibility layer introduced.
- [ ] No silent fallback introduced.
- [ ] No hidden default or fake data introduced.
- [ ] Errors remain explicit and traceable.

## Validation

- Commands run:
- Manual verification:

## Risks

- Known impact/risk:
- Follow-up tasks:
