### PR TITLE
fix: worker handlers should read analysisModel from user config fallback

### DIFF
--- a/src/lib/workers/handlers/script-to-storyboard.ts
+++ b/src/lib/workers/handlers/script-to-storyboard.ts
@@ -1,7 +1,7 @@
 import type { Job } from 'bullmq'
 import { prisma } from '@/lib/prisma'
 import { chatCompletion, getCompletionParts } from '@/lib/llm-client'
-import { resolveProjectModelCapabilityGenerationOptions } from '@/lib/config-service'
+import { getProjectModelConfig, resolveProjectModelCapabilityGenerationOptions } from '@/lib/config-service'
 import { withInternalLLMStreamCallbacks } from '@/lib/llm-observe/internal-stream-context'
 import { logAIAnalysis } from '@/lib/logging/semantic'
 import { onProjectNameAvailable } from '@/lib/logging/file-writer'
@@ -92,7 +92,8 @@ export async function handleScriptToStoryboardTask(job: Job<TaskJobData>) {
     throw new Error('No clips found')
   }
 
-  const model = inputModel || novelData.analysisModel || ''
+  const projectModelConfig = await getProjectModelConfig(projectId, job.data.userId)
+  const model = inputModel || projectModelConfig.analysisModel || ''
   if (!model) {
     throw new Error('analysisModel is not configured')
   }

--- a/src/lib/workers/handlers/story-to-script.ts
+++ b/src/lib/workers/handlers/story-to-script.ts
@@ -1,7 +1,7 @@
 import type { Job } from 'bullmq'
 import { prisma } from '@/lib/prisma'
 import { chatCompletion, getCompletionParts } from '@/lib/llm-client'
-import { resolveProjectModelCapabilityGenerationOptions } from '@/lib/config-service'
+import { getProjectModelConfig, resolveProjectModelCapabilityGenerationOptions } from '@/lib/config-service'
 import { withInternalLLMStreamCallbacks } from '@/lib/llm-observe/internal-stream-context'
 import { logAIAnalysis } from '@/lib/logging/semantic'
 import { onProjectNameAvailable } from '@/lib/logging/file-writer'
@@ -86,7 +86,8 @@ export async function handleStoryToScriptTask(job: Job<TaskJobData>) {
     throw new Error('Episode not found')
   }
 
-  const model = inputModel || novelData.analysisModel || ''
+  const projectModelConfig = await getProjectModelConfig(projectId, job.data.userId)
+  const model = inputModel || projectModelConfig.analysisModel || ''
   if (!model) {
     throw new Error('analysisModel is not configured')
   }

--- a/src/lib/workers/handlers/voice-analyze.ts
+++ b/src/lib/workers/handlers/voice-analyze.ts
@@ -1,6 +1,7 @@
 import type { Job } from 'bullmq'
 import { prisma } from '@/lib/prisma'
 import { chatCompletion, getCompletionContent } from '@/lib/llm-client'
+import { getProjectModelConfig } from '@/lib/config-service'
 import { withInternalLLMStreamCallbacks } from '@/lib/llm-observe/internal-stream-context'
 import { buildCharactersIntroduction } from '@/lib/constants'
 import { reportTaskProgress } from '@/lib/workers/shared'
@@ -81,7 +82,8 @@ export async function handleVoiceAnalyzeTask(job: Job<TaskJobData>) {
     throw new Error('No novel text to analyze')
   }
 
-  const analysisModel = novelPromotionData.analysisModel
+  const projectModelConfig = await getProjectModelConfig(projectId, job.data.userId)
+  const analysisModel = projectModelConfig.analysisModel
   if (!analysisModel) {
     throw new Error('analysisModel is not configured')
   }


### PR DESCRIPTION
- Changed 6 worker handlers to use getProjectModelConfig instead of direct DB read
- Added regression tests for user config fallback scenario
- Fixes issue where user-configured analysisModel was not recognized by workers

## Summary

- What changed:
- Why:

## Architecture Plan Sync (Required)

- Master plan file: `/Users/earth/Desktop/waoowaoo/docs/architecture-unification-master-plan.md`
- [ ] I updated the phase status board (`✅/🔄/⏸/⚠️`) in the same PR.
- [ ] I recorded concrete file-level changes under the corresponding phase.
- [ ] I kept the plan date/current-context consistent with the code changes in this PR.

## Phase Status Delta (Required)

| Phase | Before | After | Evidence (file path) |
| --- | --- | --- | --- |
| e.g. Phase 1.2 | 🔄 | ✅ | `src/lib/query/task-target-overlay.ts` |

## Guardrails Checklist (Required)

- [ ] No compatibility layer introduced.
- [ ] No silent fallback introduced.
- [ ] No hidden default or fake data introduced.
- [ ] Errors remain explicit and traceable.

## Validation

- Commands run:
- Manual verification:

## Risks

- Known impact/risk:
- Follow-up tasks:
