### PR TITLE
fix: 完善 openai 兼容层配置与 think 解析

### DIFF
--- a/src/types/ws.d.ts
+++ b/src/types/ws.d.ts
@@ -1,0 +1,19 @@
+declare module 'ws' {
+  export type WsEventName = 'open' | 'error' | 'close' | 'message'
+
+  export interface WsClientOptions {
+    headers?: Record<string, string>
+  }
+
+  export default class WebSocket {
+    constructor(url: string, options?: WsClientOptions)
+    on(event: 'open', listener: () => void): this
+    on(event: 'error', listener: (error: Error) => void): this
+    on(event: 'close', listener: (code: number, reason: Buffer) => void): this
+    on(event: 'message', listener: (data: unknown) => void): this
+    send(data: string): void
+    close(code?: number): void
+  }
+
+  export { WebSocket }
+}


### PR DESCRIPTION
## Summary

- What changed: 
  - 完善openai接入代码，可以设置多种类型模型，而不只是文本。
  - 允许配置openai兼容渠道进行生成，价格如果是llm可识别自定义价格
  - 处理think标签类型思考链
- Why:

## Architecture Plan Sync (Required)

- Master plan file: `/Users/earth/Desktop/waoowaoo/docs/architecture-unification-master-plan.md`
- [ ] I updated the phase status board (`✅/🔄/⏸/⚠️`) in the same PR.
- [ ] I recorded concrete file-level changes under the corresponding phase.
- [ ] I kept the plan date/current-context consistent with the code changes in this PR.

## Phase Status Delta (Required)

| Phase | Before | After | Evidence (file path) |
| --- | --- | --- | --- |
| e.g. Phase 1.2 | 🔄 | ✅ | `src/lib/query/task-target-overlay.ts` |

## Guardrails Checklist (Required)

- [x] No compatibility layer introduced.
- [x] No silent fallback introduced.
- [x] No hidden default or fake data introduced.
- [x] Errors remain explicit and traceable.

## Validation

- Commands run:
- Manual verification:

## Risks

- Known impact/risk:
- Follow-up tasks:


<img width="1216" height="818" alt="image" src="https://github.com/user-attachments/assets/33890848-473b-422c-993c-e7fa568cfa4c" />
