### PR TITLE
fix: add user-agent header for cloudflare-proxied image apis

### DIFF
--- a/src/lib/generators/image/openai-compatible.ts
+++ b/src/lib/generators/image/openai-compatible.ts
@@ -218,6 +218,10 @@ export class OpenAICompatibleImageGenerator extends BaseImageGenerator {
     const client = new OpenAI({
       apiKey: config.apiKey,
       baseURL: config.baseUrl,
+      // cloudflare blocks requests without a browser user-agent, returns 403
+      defaultHeaders: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      },
     })
     const model = (this.modelId || normalizeModel(options.modelId) || 'gpt-image-1').trim()
     const responseFormat = normalizeResponseFormat(options.responseFormat)


### PR DESCRIPTION
when using a cloudflare-proxied url as the api base, cloudflare drops the request with 403 because the openai sdk sends requests without a user-agent header by default.

passing a browser user-agent via defaultHeaders in the openai client constructor fixes it, as reported in #43.

changed file: src/lib/generators/image/openai-compatible.ts