### PR TITLE
fix: log errors in silent catch blocks instead of swallowing them

### DIFF
--- a/src/app/api/novel-promotion/[projectId]/panel/select-candidate/route.ts
+++ b/src/app/api/novel-promotion/[projectId]/panel/select-candidate/route.ts
@@ -16,7 +16,8 @@ function parseUnknownArray(jsonValue: string | null): unknown[] {
   try {
     const parsed = JSON.parse(jsonValue)
     return Array.isArray(parsed) ? parsed : []
-  } catch {
+  } catch (err) {
+    console.warn('[parseUnknownArray] failed to parse JSON value:', err)
     return []
   }
 }

--- a/src/app/api/novel-promotion/[projectId]/route.ts
+++ b/src/app/api/novel-promotion/[projectId]/route.ts
@@ -84,7 +84,8 @@ function parseStoredCapabilitySelections(raw: string | null | undefined): Capabi
   if (!raw) return {}
   try {
     return normalizeCapabilitySelectionsInput(JSON.parse(raw) as unknown, { allowLegacyAspectRatio: true })
-  } catch {
+  } catch (err) {
+    console.warn('[parseStoredCapabilitySelections] failed to parse capability selections, stored value may be corrupt:', err)
     return {}
   }
 }

--- a/src/lib/billing/service.ts
+++ b/src/lib/billing/service.ts
@@ -536,7 +536,8 @@ async function loadUserCustomPricing(
   let models: Array<{ modelKey: string; customPricing?: unknown }>
   try {
     models = JSON.parse(pref.customModels) as typeof models
-  } catch {
+  } catch (err) {
+    console.warn('[getCustomModelPricing] failed to parse customModels for user:', userId, err)
     return null
   }
   if (!Array.isArray(models)) return null

--- a/src/lib/cos.ts
+++ b/src/lib/cos.ts
@@ -385,7 +385,8 @@ export function extractCOSKey(urlOrKey: string | null | undefined): string | nul
     const url = new URL(urlOrKey)
     // 移除开头的 /
     return url.pathname.startsWith('/') ? url.pathname.slice(1) : url.pathname
-  } catch {
+  } catch (err) {
+    console.warn('[extractCOSKey] failed to parse url, returning null:', urlOrKey, err)
     return null
   }
 }

--- a/src/lib/media/attach.ts
+++ b/src/lib/media/attach.ts
@@ -9,7 +9,8 @@ function parseStringArray(value: unknown): string[] {
   try {
     const parsed = JSON.parse(value)
     return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : []
-  } catch {
+  } catch (err) {
+    console.warn('[parseStringArray] failed to parse value as JSON array:', err)
     return []
   }
 }

--- a/src/lib/media/service.ts
+++ b/src/lib/media/service.ts
@@ -212,7 +212,8 @@ export async function resolveMediaRefsFromLegacyJsonArray(jsonStr: unknown): Pro
     )
 
     return refs.filter((v): v is MediaRef => !!v)
-  } catch {
+  } catch (err) {
+    console.warn('[resolveMediaRefsFromLegacyJsonArray] failed to parse json array, value may be corrupt:', err)
     return []
   }
 }

--- a/src/lib/task/has-output.ts
+++ b/src/lib/task/has-output.ts
@@ -10,7 +10,8 @@ function parseJsonStringArray(raw: string | null | undefined): string[] {
     const parsed = JSON.parse(raw)
     if (!Array.isArray(parsed)) return []
     return parsed.filter((item): item is string => isNonEmptyString(item))
-  } catch {
+  } catch (err) {
+    console.warn('[parseJsonStringArray] failed to parse value, data may be corrupt:', err)
     return []
   }
 }

--- a/src/types/character-profile.ts
+++ b/src/types/character-profile.ts
@@ -52,7 +52,8 @@ export function parseProfileData(profileDataJson: string | null): CharacterProfi
     if (!profileDataJson) return null
     try {
         return JSON.parse(profileDataJson) as CharacterProfileData
-    } catch {
+    } catch (err) {
+        console.warn('[parseProfileData] failed to parse profileDataJson, data may be corrupt:', err)
         return null
     }
 }

--- a/src/types/storyboard-types.ts
+++ b/src/types/storyboard-types.ts
@@ -42,7 +42,8 @@ export function getPanelCandidates(panel: NovelPromotionPanel): string[] {
     try {
         const parsed = JSON.parse(panel.imageHistory)
         return Array.isArray(parsed) ? parsed : []
-    } catch {
+    } catch (err) {
+        console.warn('[getPanelCandidates] failed to parse imageHistory, panel id:', (panel as { id?: unknown }).id, err)
         return []
     }
 }


### PR DESCRIPTION
catch blocks across several modules were silently returning null or empty arrays without any trace, so when data corruption or unexpected inputs hit these paths there was no way to know from logs.

added console.warn with function name and relevant context in each affected catch block so the error shows up somewhere.

files changed:
- src/types/character-profile.ts
- src/types/storyboard-types.ts
- src/app/api/novel-promotion/[projectId]/route.ts
- src/app/api/novel-promotion/[projectId]/panel/select-candidate/route.ts
- src/lib/media/service.ts
- src/lib/media/attach.ts
- src/lib/cos.ts
- src/lib/billing/service.ts
- src/lib/task/has-output.ts

toUrlMaybe in outbound-image.ts was left as is since it is a deliberately permissive helper whose whole point is to return null on failure.

closes #14