### PR TITLE
修复：将上游挑战页 403 归类为 EXTERNAL_ERROR，停止无效重试，并补充浏览器 User-Agent

### DIFF
--- a/src/lib/ai-runtime/errors.ts
+++ b/src/lib/ai-runtime/errors.ts
@@ -13,6 +13,7 @@ function toCode(value: string): AiRuntimeErrorCode {
 function inferEmptyResponse(message: string): boolean {
   const normalized = message.toLowerCase()
   return normalized.includes('stream_empty')
+    || normalized.includes('llm_empty_response')
     || normalized.includes('empty response')
     || normalized.includes('no meaningful content')
     || normalized.includes('channel:empty_response')

--- a/src/lib/errors/normalize.ts
+++ b/src/lib/errors/normalize.ts
@@ -38,6 +38,22 @@ function containsAny(haystack: string, needles: string[]) {
   return false
 }
 
+function isUpstreamBlocked403(message: string): boolean {
+  if (!containsAny(message, ['403', 'forbidden', 'blocked'])) return false
+  return containsAny(message, [
+    'just a moment',
+    'attention required',
+    'cloudflare',
+    'cf-chl',
+    'captcha',
+    'security check',
+    'your request was blocked',
+    'upstream',
+    '<!doctype html',
+    '<html',
+  ])
+}
+
 function buildNormalizedError(
   code: UnifiedErrorCode,
   message?: string,
@@ -63,9 +79,11 @@ function inferCodeFromMessage(message: string): UnifiedErrorCode | null {
   if (explicitMatch && isKnownErrorCode(explicitMatch[1])) {
     return explicitMatch[1]
   }
+  if (containsAny(message, ['llm_empty_response', 'stream_empty', 'empty response', 'no meaningful content', 'channel:empty_response'])) return 'GENERATION_FAILED'
 
   if (containsAny(message, ['task cancelled', 'canceled by user', 'cancelled by user', '任务已取消'])) return 'CONFLICT'
   if (containsAny(message, ['unauthorized', 'not authenticated', 'need login', '401'])) return 'UNAUTHORIZED'
+  if (isUpstreamBlocked403(message)) return 'EXTERNAL_ERROR'
   if (containsAny(message, ['forbidden', 'permission denied', '403'])) return 'FORBIDDEN'
   if (containsAny(message, ['not found', '不存在', 'missing record'])) return 'NOT_FOUND'
   if (containsAny(message, ['invalid', 'missing', 'required', 'bad request', 'fieldinvalid'])) return 'INVALID_PARAMS'
@@ -144,7 +162,12 @@ export function normalizeAnyError(input: unknown, options: NormalizeOptions = {}
 
   if (typeof errorLike.status === 'number') {
     if (errorLike.status === 401) return buildNormalizedError('UNAUTHORIZED', message, options.details, provider)
-    if (errorLike.status === 403) return buildNormalizedError('FORBIDDEN', message, options.details, provider)
+    if (errorLike.status === 403) {
+      if (isUpstreamBlocked403(lowerMessage)) {
+        return buildNormalizedError('EXTERNAL_ERROR', message, options.details, provider)
+      }
+      return buildNormalizedError('FORBIDDEN', message, options.details, provider)
+    }
     if (errorLike.status === 404) return buildNormalizedError('NOT_FOUND', message, options.details, provider)
     if (errorLike.status === 409) return buildNormalizedError('CONFLICT', message, options.details, provider)
     if (errorLike.status === 422) return buildNormalizedError('SENSITIVE_CONTENT', message, options.details, provider)

--- a/src/lib/generators/base.ts
+++ b/src/lib/generators/base.ts
@@ -1,4 +1,16 @@
 import { logWarn as _ulogWarn } from '@/lib/logging/core'
+
+function isChallenge403Message(message: string): boolean {
+    const normalized = message.trim().toLowerCase()
+    if (!normalized.includes('403')) return false
+    return normalized.includes('just a moment')
+        || normalized.includes('your request was blocked')
+        || normalized.includes('attention required')
+        || normalized.includes('cloudflare')
+        || normalized.includes('<!doctype html')
+        || normalized.includes('<html')
+        || normalized.includes('upload failed: 403')
+}
 /**
  * 生成器基础接口和类型定义
  * 
@@ -107,7 +119,7 @@ export abstract class BaseImageGenerator implements ImageGenerator {
                 _ulogWarn(`[Generator] 尝试 ${attempt}/${maxRetries} 失败: ${message}`)
 
                 // 最后一次尝试，直接抛出
-                if (attempt === maxRetries) {
+                if (attempt === maxRetries || isChallenge403Message(message)) {
                     break
                 }
 
@@ -140,7 +152,7 @@ export abstract class BaseVideoGenerator implements VideoGenerator {
                 lastError = error
                 const message = error instanceof Error ? error.message : String(error)
                 _ulogWarn(`[Video Generator] 尝试 ${attempt}/${maxRetries} 失败: ${message}`)
-                if (attempt === maxRetries) break
+                if (attempt === maxRetries || isChallenge403Message(message)) break
                 await new Promise(resolve => setTimeout(resolve, 1000 * attempt))
             }
         }

--- a/src/lib/generators/image/openai-compatible.ts
+++ b/src/lib/generators/image/openai-compatible.ts
@@ -218,6 +218,10 @@ export class OpenAICompatibleImageGenerator extends BaseImageGenerator {
     const client = new OpenAI({
       apiKey: config.apiKey,
       baseURL: config.baseUrl,
+      // cloudflare blocks requests without a browser user-agent, returns 403
+      defaultHeaders: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      },
     })
     const model = (this.modelId || normalizeModel(options.modelId) || 'gpt-image-1').trim()
     const responseFormat = normalizeResponseFormat(options.responseFormat)

--- a/src/lib/llm/chat-stream.ts
+++ b/src/lib/llm/chat-stream.ts
@@ -333,6 +333,7 @@ export async function chatCompletionStream(
       }
 
       const isOpenRouter = !!config.baseUrl?.includes('openrouter')
+      const browserLikeUserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
       const providerName = isOpenRouter ? 'openrouter' : provider
       const shouldUseAiSdk = !isOpenRouter
       if (shouldUseAiSdk) {
@@ -340,6 +341,9 @@ export async function chatCompletionStream(
           baseURL: config.baseUrl,
           apiKey: config.apiKey,
           name: providerName,
+          headers: {
+            'User-Agent': browserLikeUserAgent,
+          },
         })
         // 只有确定是支持 OpenAI 推理参数的提供商（如 OpenAI 官方、deepseek-r1 等）才传 reasoning provider options
         // gemini-compatible / 其他 OAI-compat 提供商不支持 forceReasoning/reasoningEffort，会导致空响应
@@ -639,6 +643,9 @@ export async function chatCompletionStream(
       const client = new OpenAI({
         baseURL: config.baseUrl,
         apiKey: config.apiKey,
+        defaultHeaders: {
+          'User-Agent': browserLikeUserAgent,
+        },
       })
 
       const extraParams: Record<string, unknown> = {}

--- a/src/lib/llm/vision.ts
+++ b/src/lib/llm/vision.ts
@@ -180,6 +180,10 @@ export async function chatCompletionWithVision(
       const client = new OpenAI({
         baseURL: config.baseUrl,
         apiKey: config.apiKey,
+        // Cloudflare may block requests without a browser-like User-Agent.
+        defaultHeaders: {
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        },
       })
 
       const content: OpenAiVisionContentItem[] = []

--- a/src/lib/workers/shared.ts
+++ b/src/lib/workers/shared.ts
@@ -128,6 +128,21 @@ function resolveNextBackoffMs(job: Job<TaskJobData>, failedAttempt: number): num
   return baseDelay
 }
 
+function isUpstreamChallenge403(message: string): boolean {
+  const normalized = message.trim().toLowerCase()
+  if (!normalized) return false
+  if (!normalized.includes('403')) return false
+  return (
+    normalized.includes('just a moment')
+    || normalized.includes('your request was blocked')
+    || normalized.includes('attention required')
+    || normalized.includes('cloudflare')
+    || normalized.includes('<!doctype html')
+    || normalized.includes('<html')
+    || normalized.includes('upload failed: 403')
+  )
+}
+
 function shouldRetryInQueue(params: {
   job: Job<TaskJobData>
   normalizedError: NormalizedError
@@ -139,7 +154,11 @@ function shouldRetryInQueue(params: {
 } {
   const maxAttempts = resolveQueueAttempts(params.job)
   const failedAttempt = resolveAttemptsMade(params.job) + 1
-  const enabled = params.normalizedError.retryable && failedAttempt < maxAttempts
+  const upstreamChallenge403 = params.normalizedError.code === 'EXTERNAL_ERROR'
+    && isUpstreamChallenge403(params.normalizedError.message)
+  const enabled = params.normalizedError.retryable
+    && failedAttempt < maxAttempts
+    && !upstreamChallenge403
   return {
     enabled,
     failedAttempt,


### PR DESCRIPTION
## 问题描述
在上游返回挑战页/拦截页（HTTP 403）时，当前链路会出现以下情况：

1. 该类 403 被归类为 `FORBIDDEN`，与实际语义不一致（更接近外部依赖拦截）。
2. 任务在队列和生成器层仍会继续重试，产生无效重试与额外耗时。
3. 部分 OpenAI-compatible 请求未携带浏览器风格 `User-Agent`，在部分环境下更容易触发上游拦截。
4. `llm_empty_response` 未完整纳入空响应归一化识别。

## 改动内容
1. 新增上游挑战页 403 识别逻辑（Cloudflare/HTML challenge 相关特征）。
2. 将该类 403 从 `FORBIDDEN` 调整为 `EXTERNAL_ERROR`。
3. 在队列重试与生成器重试逻辑中，对该类 403 直接停止重试。
4. 在 OpenAI-compatible 相关调用链路补充浏览器风格 `User-Agent`。
5. 增强空响应识别，补充 `llm_empty_response` 等关键词映射。

## 涉及文件
1. `src/lib/ai-runtime/errors.ts`
2. `src/lib/errors/normalize.ts`
3. `src/lib/generators/base.ts`
4. `src/lib/generators/image/openai-compatible.ts`
5. `src/lib/llm/chat-stream.ts`
6. `src/lib/llm/vision.ts`
7. `src/lib/workers/shared.ts`

## 行为变化
1. challenge 类型 403 归类为 `EXTERNAL_ERROR`。
2. challenge 类型 403 不再执行无效重试。
3. OpenAI-compatible 请求默认带浏览器风格 UA。
4. 空响应错误归一化覆盖更完整。

## 验证情况
1. challenge 特征 403 可归类为 `EXTERNAL_ERROR`。
2. 该类错误在队列与生成器侧不再继续重试。
3. chat/vision/image 调用链路已包含 `User-Agent`。
4. `llm_empty_response` 可进入空响应失败语义分支。

## 风险与回滚
1. 403 分类口径变化后，`FORBIDDEN` 与 `EXTERNAL_ERROR` 指标分布会变化。
2. challenge 关键词策略可能存在误判/漏判，后续可按样本迭代。
3. 回滚本 PR 对应提交可恢复原行为。