### PR TITLE
非 Docker 场景下部署流程说明

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ certificates
 
 # local temporary snapshots for old-version verification
 .tmp-old-snapshot-*/
+
+# yarn.lock
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -88,6 +88,68 @@ git pull
 docker compose down && docker compose up -d --build
 ```
 
+## 🖥️ 非 Docker 部署 / Non-Docker Deployment
+
+如果你不使用 Docker，而是自行安装 MySQL 与 Redis，请按以下步骤。  
+If you do not use Docker and run MySQL + Redis yourself, follow these steps.
+
+1. 🧰 安装运行环境 / Install runtime dependencies:
+   - Node.js：建议与镜像保持一致，使用 `20.x`（参考 `Dockerfile` 的 `node:20-alpine`）
+   - MySQL：`8.0`（参考 `docker-compose.yml` 的 `mysql:8.0`）
+   - Redis：`7.x`（参考 `docker-compose.yml` 的 `redis:7-alpine`）
+
+2. 📦 安装依赖 / Install dependencies（任选其一 / choose one）：
+
+```bash
+yarn install
+```
+
+```bash
+npm install
+```
+
+3. 🧾 复制环境变量模板并修改 / Copy `.env` template and edit:
+
+```bash
+cp .env.example .env
+```
+
+4. ⚙️ 修改 `.env` 必填配置 / Update required `.env` values:
+   - `DATABASE_URL="mysql://<user>:<password>@127.0.0.1:3306/waoowaoo"`
+   - `REDIS_HOST=127.0.0.1`
+   - `REDIS_PORT=6379`
+
+5. 🗄️ 创建数据库 / Create database in MySQL:
+
+```sql
+CREATE DATABASE IF NOT EXISTS waoowaoo CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+```
+
+6. 🧱 初始化数据库结构（Prisma 建表）/ Initialize database schema (Prisma):
+
+```bash
+npx prisma db push --skip-generate
+```
+
+```bash
+yarn prisma db push --skip-generate
+```
+
+7. 🚀 启动项目 / Start the app:
+
+```bash
+yarn dev
+```
+
+or:
+
+```bash
+npm run dev
+```
+
+> 💡 提示 / Note: 非 Docker 模式不会自动执行 `prisma db push`，如未初始化会出现数据库连接或表不存在错误。  
+> In non-Docker mode, `prisma db push` is not run automatically. Missing this step can cause DB connection or table-not-found errors.
+
 ---
 
 ## 🔧 API 配置 / API Configuration


### PR DESCRIPTION
## Summary 
 
 - What changed: 
 - 在 `README.md` 的“非 Docker 部署 / Non-Docker Deployment”章节补充并统一了本地部署说明：新增运行环境版本参考（Node.js 20.x、MySQL 8.0、Redis 7.x），明确非 Docker 需自行安装 MySQL/Redis；保留并完善 `.env`、建库、Prisma 初始化（含 `yarn prisma db push --skip-generate`）与启动步骤；
 - Why: 
 - 非 Docker 场景下部署流程说明
 
 ## Phase Status Delta (Required) 
 
 | Phase | Before | After | Evidence (file path) | 
 | --- | --- | --- | --- | 
 | 文档完善（非 Docker 部署说明） | 🔄 | ✅ | `README.md` | 

 ## Risks 

 - Known impact/risk: 
 - 仅文档变更，无运行时代码改动，风险低；若用户环境版本偏离建议版本，仍可能出现本地兼容性差异。 