### PR TITLE
fix: improve image MIME type detection for object storage services

### DIFF
--- a/src/lib/media/outbound-image.ts
+++ b/src/lib/media/outbound-image.ts
@@ -163,9 +163,18 @@ function toUrlMaybe(value: string): URL | null {
   return null
 }
 
+function detectMimeFromBuffer(buffer: Buffer): string | null {
+  if (buffer.length < 4) return null
+  if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) return 'image/png'
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return 'image/jpeg'
+  if (buffer.length >= 12 && buffer.subarray(0, 4).toString('ascii') === 'RIFF' && buffer.subarray(8, 12).toString('ascii') === 'WEBP') return 'image/webp'
+  if (buffer.length >= 6 && (buffer.subarray(0, 6).toString('ascii') === 'GIF87a' || buffer.subarray(0, 6).toString('ascii') === 'GIF89a')) return 'image/gif'
+  return null
+}
+
 function guessContentType(input: string, contentTypeHeader: string | null): string {
   const headerType = contentTypeHeader?.split(';')[0]?.trim()
-  if (headerType) return headerType
+  if (headerType && headerType !== DEFAULT_CONTENT_TYPE) return headerType
   const parsed = toUrlMaybe(input)
   const pathname = parsed?.pathname ?? input
   const ext = path.extname(pathname).toLowerCase()
@@ -308,8 +317,8 @@ export async function normalizeToBase64ForGeneration(input: string): Promise<str
     })
   }
 
-  const mimeType = guessContentType(normalizedUrl, response.headers.get('content-type'))
   const buffer = Buffer.from(await response.arrayBuffer())
+  const mimeType = detectMimeFromBuffer(buffer) || guessContentType(normalizedUrl, response.headers.get('content-type'))
   return `data:${mimeType};base64,${buffer.toString('base64')}`
 }
 


### PR DESCRIPTION
## Problem

When using object storage services (MinIO, S3, etc.), MiniMax video generation fails with the error:
```
MiniMax: invalid params, first_frame_image: failed to parse base64 data
```

### Root Cause

1. Object storage services like MinIO return `Content-Type: application/octet-stream` by default for uploaded images without explicit content type
2. The current code trusts the HTTP Content-Type header directly
3. This generates Data URLs in the format `data:application/octet-stream;base64,...`
4. MiniMax API requires explicit image MIME types (e.g., `image/png`, `image/jpeg`)

## Solution

This PR adds magic byte-based MIME type detection to accurately identify image formats:

### Changes

1. **Added `detectMimeFromBuffer` function**
   - Detects image format from file header magic bytes
   - Supports PNG (`\x89PNG`), JPEG (`\xFF\xD8\xFF`), WebP (`RIFF...WEBP`), GIF (`GIF87a`/`GIF89a`)

2. **Modified `guessContentType` function**
   - No longer blindly trusts `application/octet-stream` from headers
   - Falls back to file extension detection when header is unreliable

3. **Adjusted detection priority in `normalizeToBase64ForGeneration`**
   - Magic byte detection (most accurate)
   - HTTP Content-Type header (if not octet-stream)
   - File extension (fallback)

### Code Changes

**File**: `src/lib/media/outbound-image.ts`

- Added `detectMimeFromBuffer` function for magic byte detection
- Modified `guessContentType` to ignore `application/octet-stream`
- Reordered MIME type detection to prioritize magic bytes

## Testing

- ✅ MiniMax video generation now works correctly with MinIO storage
- ✅ Correctly identifies PNG/JPEG/WebP/GIF formats from file content
- ✅ Backward compatible - no breaking changes to existing functionality
- ✅ Tested with various object storage services (MinIO, S3-compatible)

### Before Fix

```
DEBUG len=2373649 prefix=data:application/octet-stream;base64,iVBORw0KGgo...
Error: failed to parse base64 data
```

### After Fix

```
DEBUG len=2373649 prefix=data:image/png;base64,iVBORw0KGgo...
Success: Video generation task submitted
```

## Impact

- Fixes MiniMax Hailuo video generation functionality
- Improves accuracy of image MIME type detection for all use cases
- Supports more object storage services (MinIO, S3, Alibaba OSS, etc.)
- Benefits all users who use object storage instead of local file system

## Checklist

- [x] Code has been tested
- [x] Backward compatible
- [x] Follows project code style
- [x] No breaking changes
- [x] No API keys or sensitive information included
