### PR TITLE
fix(docker): harden npm install

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       MINIO_SECRET_KEY: "minioadmin"
       MINIO_FORCE_PATH_STYLE: "true"
       # 认证
-      NEXTAUTH_URL: "http://0.0.0.0:3000"
+      NEXTAUTH_URL: "http://localhost:3000"
       NEXTAUTH_SECRET: "waoowaoo-default-secret-2026"
       # 内部密钥
       CRON_SECRET: "waoowaoo-docker-cron-secret"


### PR DESCRIPTION
在容器构建与本地 docker-compose 场景下，存在两个一致性问题：

  1. `npm ci` 依赖安装对 registry/host 行为不够显式，构建稳定性受环境影响。
  2. 
  ## 变更内容

  1. 更新 `Dockerfile`（deps 阶段）：
  - 增加 `npm config set registry https://registry.npmjs.org`
  - 增加 `npm config set replace-registry-host always`
  - 将安装命令改为 `npm ci --no-audit --no-fund`


  ## 影响范围

  - 仅影响 Docker 构建与 compose 运行时配置。
  - 不涉及业务逻辑、数据库结构或 API 行为变更。

  ## 风险与取舍

  - `npm ci --no-audit --no-fund` 目标是减少非必要网络交互，提升构建可预测性；安全审计
  可在独立 CI 流程执行。

  ## 验证建议

  1. 执行 `docker compose build`，确认依赖安装阶段正常通过。
  3. 执行 `docker compose up -d`，确认服务可正常启动。
  4. 访问认证流程，确认 NextAuth 回调与登录流程正常。