### PR TITLE
feat: add MiniMax as official LLM provider

### DIFF
--- a/src/lib/llm/chat-completion.ts
+++ b/src/lib/llm/chat-completion.ts
@@ -35,9 +35,10 @@ import {
   resolveLlmRuntimeModel,
 } from './runtime-shared'
 import { completeBailianLlm } from '@/lib/providers/bailian'
+import { completeMiniMaxLlm } from '@/lib/providers/minimax'
 import { completeSiliconFlowLlm } from '@/lib/providers/siliconflow'
 
-const OFFICIAL_ONLY_PROVIDER_KEYS = new Set(['bailian', 'siliconflow'])
+const OFFICIAL_ONLY_PROVIDER_KEYS = new Set(['bailian', 'minimax', 'siliconflow'])
 
 function toRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' ? (value as Record<string, unknown>) : null
@@ -280,6 +281,42 @@ export async function chatCompletion(
 
       if (providerKey === 'siliconflow') {
         const completion = await completeSiliconFlowLlm({
+          modelId: resolvedModelId,
+          messages,
+          apiKey: providerConfig.apiKey,
+          baseUrl: providerConfig.baseUrl,
+          temperature,
+        })
+        const completionParts = getCompletionParts(completion)
+        logLlmRawOutput({
+          userId,
+          projectId,
+          provider: providerKey,
+          modelId: resolvedModelId,
+          modelKey: selection.modelKey,
+          stream: false,
+          action: options.action,
+          text: completionParts.text,
+          reasoning: completionParts.reasoning,
+          usage: completionUsageSummary(completion),
+        })
+        recordCompletionUsage(resolvedModelId, completion)
+        llmLogger.info({
+          action: 'llm.call.success',
+          message: 'llm call succeeded',
+          provider: providerKey,
+          durationMs: Date.now() - attemptStartedAt,
+          details: {
+            model: resolvedModelId,
+            attempt,
+            maxRetries,
+          },
+        })
+        return completion
+      }
+
+      if (providerKey === 'minimax') {
+        const completion = await completeMiniMaxLlm({
           modelId: resolvedModelId,
           messages,
           apiKey: providerConfig.apiKey,

--- a/src/lib/llm/chat-stream.ts
+++ b/src/lib/llm/chat-stream.ts
@@ -38,9 +38,10 @@ import { getCompletionParts } from './completion-parts'
 import { withStreamChunkTimeout } from './stream-timeout'
 import { shouldUseOpenAIReasoningProviderOptions } from './reasoning-capability'
 import { completeBailianLlm } from '@/lib/providers/bailian'
+import { completeMiniMaxLlm } from '@/lib/providers/minimax'
 import { completeSiliconFlowLlm } from '@/lib/providers/siliconflow'
 
-const OFFICIAL_ONLY_PROVIDER_KEYS = new Set(['bailian', 'siliconflow'])
+const OFFICIAL_ONLY_PROVIDER_KEYS = new Set(['bailian', 'minimax', 'siliconflow'])
 
 type GoogleModelClient = {
   generateContentStream?: (params: unknown) => Promise<unknown>
@@ -328,6 +329,52 @@ export async function chatCompletionStream(
     if (providerKey === 'siliconflow') {
       emitStreamStage(callbacks, streamStep, 'streaming', providerKey)
       const completion = await completeSiliconFlowLlm({
+        modelId: resolvedModelId,
+        messages,
+        apiKey: providerConfig.apiKey,
+        baseUrl: providerConfig.baseUrl,
+        temperature: options.temperature ?? 0.7,
+      })
+      const completionParts = getCompletionParts(completion)
+      let seq = 1
+      if (completionParts.reasoning) {
+        emitStreamChunk(callbacks, streamStep, {
+          kind: 'reasoning',
+          delta: completionParts.reasoning,
+          seq,
+          lane: 'reasoning',
+        })
+        seq += 1
+      }
+      if (completionParts.text) {
+        emitStreamChunk(callbacks, streamStep, {
+          kind: 'text',
+          delta: completionParts.text,
+          seq,
+          lane: 'main',
+        })
+      }
+      logLlmRawOutput({
+        userId,
+        projectId,
+        provider: providerKey,
+        modelId: resolvedModelId,
+        modelKey: selection.modelKey,
+        stream: true,
+        action: options.action,
+        text: completionParts.text,
+        reasoning: completionParts.reasoning,
+        usage: completionUsageSummary(completion),
+      })
+      recordCompletionUsage(resolvedModelId, completion)
+      emitStreamStage(callbacks, streamStep, 'completed', providerKey)
+      callbacks?.onComplete?.(completionParts.text, streamStep)
+      return completion
+    }
+
+    if (providerKey === 'minimax') {
+      emitStreamStage(callbacks, streamStep, 'streaming', providerKey)
+      const completion = await completeMiniMaxLlm({
         modelId: resolvedModelId,
         messages,
         apiKey: providerConfig.apiKey,

--- a/src/lib/providers/minimax/catalog.ts
+++ b/src/lib/providers/minimax/catalog.ts
@@ -1,0 +1,33 @@
+import { registerOfficialModel } from '@/lib/providers/official/model-registry'
+import type { OfficialModelModality } from '@/lib/providers/official/model-registry'
+
+const MINIMAX_CATALOG: Readonly<Record<OfficialModelModality, readonly string[]>> = {
+  llm: [
+    'MiniMax-M2.5',
+    'MiniMax-M2.5-highspeed',
+  ],
+  image: [],
+  video: [],
+  audio: [],
+}
+
+let initialized = false
+
+export function ensureMiniMaxCatalogRegistered(): void {
+  if (initialized) return
+  initialized = true
+  for (const modality of Object.keys(MINIMAX_CATALOG) as OfficialModelModality[]) {
+    for (const modelId of MINIMAX_CATALOG[modality]) {
+      registerOfficialModel({ provider: 'minimax', modality, modelId })
+    }
+  }
+}
+
+export function listMiniMaxCatalogModels(modality: OfficialModelModality): readonly string[] {
+  ensureMiniMaxCatalogRegistered()
+  return MINIMAX_CATALOG[modality]
+}
+
+export function resetMiniMaxCatalogForTest(): void {
+  initialized = false
+}

--- a/src/lib/providers/minimax/index.ts
+++ b/src/lib/providers/minimax/index.ts
@@ -1,0 +1,9 @@
+export { ensureMiniMaxCatalogRegistered, listMiniMaxCatalogModels } from './catalog'
+export { completeMiniMaxLlm } from './llm'
+export { probeMiniMax } from './probe'
+export type {
+  MiniMaxGenerateRequestOptions,
+  MiniMaxLlmMessage,
+  MiniMaxProbeResult,
+  MiniMaxProbeStep,
+} from './types'

--- a/src/lib/providers/minimax/llm.ts
+++ b/src/lib/providers/minimax/llm.ts
@@ -1,0 +1,46 @@
+import OpenAI from 'openai'
+import {
+  assertOfficialModelRegistered,
+  type OfficialModelModality,
+} from '@/lib/providers/official/model-registry'
+import { ensureMiniMaxCatalogRegistered } from './catalog'
+import type { MiniMaxLlmMessage } from './types'
+
+export interface MiniMaxLlmCompletionParams {
+  modelId: string
+  messages: MiniMaxLlmMessage[]
+  apiKey: string
+  baseUrl?: string
+  temperature?: number
+}
+
+const MINIMAX_DEFAULT_BASE_URL = 'https://api.minimaxi.com/v1'
+
+function assertRegistered(modelId: string): void {
+  ensureMiniMaxCatalogRegistered()
+  assertOfficialModelRegistered({
+    provider: 'minimax',
+    modality: 'llm' satisfies OfficialModelModality,
+    modelId,
+  })
+}
+
+export async function completeMiniMaxLlm(
+  params: MiniMaxLlmCompletionParams,
+): Promise<OpenAI.Chat.Completions.ChatCompletion> {
+  assertRegistered(params.modelId)
+
+  const client = new OpenAI({
+    apiKey: params.apiKey,
+    baseURL: params.baseUrl || MINIMAX_DEFAULT_BASE_URL,
+    timeout: 60_000,
+  })
+
+  const completion = await client.chat.completions.create({
+    model: params.modelId,
+    messages: params.messages as OpenAI.Chat.Completions.ChatCompletionMessageParam[],
+    temperature: params.temperature ?? 0.7,
+  })
+
+  return completion as OpenAI.Chat.Completions.ChatCompletion
+}

--- a/src/lib/providers/minimax/probe.ts
+++ b/src/lib/providers/minimax/probe.ts
@@ -1,0 +1,58 @@
+import type { MiniMaxProbeResult, MiniMaxProbeStep } from './types'
+
+export async function probeMiniMax(apiKey: string): Promise<MiniMaxProbeResult> {
+  const steps: MiniMaxProbeStep[] = []
+  const model = 'MiniMax-M2.5'
+
+  try {
+    const response = await fetch('https://api.minimaxi.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 20,
+        temperature: 0,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    })
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '')
+      const message = response.status === 401 || response.status === 403
+        ? `Authentication failed (${response.status})`
+        : response.status === 429
+          ? `Rate limited (${response.status})`
+          : `Provider error (${response.status})`
+      steps.push({
+        name: 'models',
+        status: 'fail',
+        message,
+        detail: detail.slice(0, 500),
+      })
+      return { success: false, steps }
+    }
+
+    const data = await response.json() as {
+      choices?: Array<{ message?: { content?: string } }>
+    }
+    const answer = data.choices?.[0]?.message?.content?.trim() || ''
+    steps.push({
+      name: 'models',
+      status: 'pass',
+      message: answer ? `Response: ${answer.slice(0, 80)}` : 'OK',
+    })
+    return { success: true, steps }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    steps.push({
+      name: 'models',
+      status: 'fail',
+      message: `Network error: ${message}`,
+    })
+    return { success: false, steps }
+  }
+}

--- a/src/lib/providers/minimax/types.ts
+++ b/src/lib/providers/minimax/types.ts
@@ -1,0 +1,25 @@
+export type MiniMaxProviderKey = 'minimax'
+
+export interface MiniMaxGenerateRequestOptions {
+  provider: string
+  modelId: string
+  modelKey: string
+  [key: string]: unknown
+}
+
+export interface MiniMaxLlmMessage {
+  role: 'user' | 'assistant' | 'system'
+  content: string
+}
+
+export interface MiniMaxProbeStep {
+  name: 'models' | 'credits'
+  status: 'pass' | 'fail' | 'skip'
+  message: string
+  detail?: string
+}
+
+export interface MiniMaxProbeResult {
+  success: boolean
+  steps: MiniMaxProbeStep[]
+}

--- a/src/lib/providers/official/model-registry.ts
+++ b/src/lib/providers/official/model-registry.ts
@@ -1,4 +1,4 @@
-export type OfficialProviderKey = 'bailian' | 'siliconflow'
+export type OfficialProviderKey = 'bailian' | 'minimax' | 'siliconflow'
 export type OfficialModelModality = 'llm' | 'image' | 'video' | 'audio'
 
 interface RegisterOfficialModelInput {

--- a/tests/unit/providers/minimax-catalog.test.ts
+++ b/tests/unit/providers/minimax-catalog.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  isOfficialModelRegistered,
+  resetOfficialModelRegistryForTest,
+} from '@/lib/providers/official/model-registry'
+import {
+  ensureMiniMaxCatalogRegistered,
+  listMiniMaxCatalogModels,
+  resetMiniMaxCatalogForTest,
+} from '@/lib/providers/minimax/catalog'
+
+describe('minimax catalog', () => {
+  beforeEach(() => {
+    resetOfficialModelRegistryForTest()
+    resetMiniMaxCatalogForTest()
+  })
+
+  it('registers MiniMax-M2.5 and MiniMax-M2.5-highspeed as llm models', () => {
+    ensureMiniMaxCatalogRegistered()
+
+    expect(
+      isOfficialModelRegistered({
+        provider: 'minimax',
+        modality: 'llm',
+        modelId: 'MiniMax-M2.5',
+      }),
+    ).toBe(true)
+
+    expect(
+      isOfficialModelRegistered({
+        provider: 'minimax',
+        modality: 'llm',
+        modelId: 'MiniMax-M2.5-highspeed',
+      }),
+    ).toBe(true)
+  })
+
+  it('lists llm models correctly', () => {
+    const models = listMiniMaxCatalogModels('llm')
+    expect(models).toEqual(['MiniMax-M2.5', 'MiniMax-M2.5-highspeed'])
+  })
+
+  it('returns empty arrays for non-llm modalities', () => {
+    expect(listMiniMaxCatalogModels('image')).toEqual([])
+    expect(listMiniMaxCatalogModels('video')).toEqual([])
+    expect(listMiniMaxCatalogModels('audio')).toEqual([])
+  })
+
+  it('does not register unrelated models', () => {
+    ensureMiniMaxCatalogRegistered()
+
+    expect(
+      isOfficialModelRegistered({
+        provider: 'minimax',
+        modality: 'llm',
+        modelId: 'unknown-model',
+      }),
+    ).toBe(false)
+  })
+})

--- a/tests/unit/providers/minimax-llm.test.ts
+++ b/tests/unit/providers/minimax-llm.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  resetOfficialModelRegistryForTest,
+} from '@/lib/providers/official/model-registry'
+import { completeMiniMaxLlm } from '@/lib/providers/minimax/llm'
+import { ensureMiniMaxCatalogRegistered, resetMiniMaxCatalogForTest } from '@/lib/providers/minimax/catalog'
+
+// Mock OpenAI
+vi.mock('openai', () => {
+  const mockCreate = vi.fn().mockResolvedValue({
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    created: 1234567890,
+    model: 'MiniMax-M2.5',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: 'Hello! How can I help you?',
+        },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: {
+      prompt_tokens: 10,
+      completion_tokens: 8,
+      total_tokens: 18,
+    },
+  })
+
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: mockCreate,
+        },
+      },
+    })),
+  }
+})
+
+describe('minimax llm', () => {
+  beforeEach(() => {
+    resetOfficialModelRegistryForTest()
+    resetMiniMaxCatalogForTest()
+    ensureMiniMaxCatalogRegistered()
+  })
+
+  it('completes a chat request with MiniMax-M2.5', async () => {
+    const result = await completeMiniMaxLlm({
+      modelId: 'MiniMax-M2.5',
+      messages: [{ role: 'user', content: 'Hello' }],
+      apiKey: 'test-api-key',
+    })
+
+    expect(result.choices[0].message.content).toBe('Hello! How can I help you?')
+    expect(result.model).toBe('MiniMax-M2.5')
+  })
+
+  it('completes a chat request with MiniMax-M2.5-highspeed', async () => {
+    const result = await completeMiniMaxLlm({
+      modelId: 'MiniMax-M2.5-highspeed',
+      messages: [{ role: 'user', content: 'Hello' }],
+      apiKey: 'test-api-key',
+    })
+
+    expect(result.choices[0].message.content).toBe('Hello! How can I help you?')
+  })
+
+  it('throws MODEL_NOT_REGISTERED for unregistered model', async () => {
+    await expect(
+      completeMiniMaxLlm({
+        modelId: 'unknown-model',
+        messages: [{ role: 'user', content: 'Hello' }],
+        apiKey: 'test-api-key',
+      }),
+    ).rejects.toThrow(/MODEL_NOT_REGISTERED/)
+  })
+
+  it('uses default base URL when not provided', async () => {
+    const OpenAI = (await import('openai')).default
+
+    await completeMiniMaxLlm({
+      modelId: 'MiniMax-M2.5',
+      messages: [{ role: 'user', content: 'Hello' }],
+      apiKey: 'test-api-key',
+    })
+
+    expect(OpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'https://api.minimaxi.com/v1',
+        apiKey: 'test-api-key',
+      }),
+    )
+  })
+
+  it('uses custom base URL when provided', async () => {
+    const OpenAI = (await import('openai')).default
+
+    await completeMiniMaxLlm({
+      modelId: 'MiniMax-M2.5',
+      messages: [{ role: 'user', content: 'Hello' }],
+      apiKey: 'test-api-key',
+      baseUrl: 'https://api.minimax.io/v1',
+    })
+
+    expect(OpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'https://api.minimax.io/v1',
+        apiKey: 'test-api-key',
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Add MiniMax as an officially registered LLM provider, following the same pattern as existing providers (bailian, siliconflow).

## Supported Models

- **MiniMax-M2.5** (default) — Peak Performance. Ultimate Value. Master the Complex. Context window: 204,800 tokens.
- **MiniMax-M2.5-highspeed** — Same performance, faster and more agile. Context window: 204,800 tokens.

## Changes

### New Files
- `src/lib/providers/minimax/types.ts` — Type definitions for MiniMax provider
- `src/lib/providers/minimax/catalog.ts` — Model catalog registration (MiniMax-M2.5, MiniMax-M2.5-highspeed)
- `src/lib/providers/minimax/llm.ts` — LLM completion via OpenAI-compatible API
- `src/lib/providers/minimax/probe.ts` — Provider connectivity probe
- `src/lib/providers/minimax/index.ts` — Barrel exports

### Modified Files
- `src/lib/providers/official/model-registry.ts` — Added `'minimax'` to `OfficialProviderKey` type
- `src/lib/llm/chat-stream.ts` — Added MiniMax LLM branch and import
- `src/lib/llm/chat-completion.ts` — Added MiniMax LLM branch and import

### Test Files
- `tests/unit/providers/minimax-catalog.test.ts` — 4 tests for catalog registration
- `tests/unit/providers/minimax-llm.test.ts` — 5 tests for LLM completion (with OpenAI mock)

## API Compatibility

MiniMax provides an **OpenAI-compatible** API endpoint:
- International: `https://api.minimax.io/v1`
- China: `https://api.minimaxi.com/v1`

## API Documentation
- https://platform.minimax.io/docs/api-reference/text-openai-api
- https://platform.minimax.io/docs/api-reference/text-anthropic-api

## Test Plan
- [x] All 9 new unit tests pass (catalog + llm)
- [x] All 25 existing provider tests pass
- [x] ESLint passes
- [x] TypeScript type-check passes