### PR TITLE
security: fix IP rate limit bypass vulnerability

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -126,19 +126,20 @@ export async function checkRateLimit(
  * 依次检查常见反向代理头，最终回退到 127.0.0.1。
  */
 export function getClientIp(req: NextRequest): string {
-    // x-forwarded-for 可能包含多个 IP（逗号分隔），取第一个
+    // 1. 优先使用 Next.js 提供的 ip 属性
+    // 这通常由底层平台（如 Vercel）或正确配置的反向代理填充，相对更可靠
+    if (req.ip) return req.ip
+
+    // 2. 其次检查 X-Real-IP，这通常由内部反向代理设置
+    const realIp = req.headers.get('x-real-ip')
+    if (realIp) return realIp.trim()
+
+    // 3. 最后才考虑 X-Forwarded-For
+    // 注意：如果应用直接暴露在公网且没有受信代理，该头部可被伪造
     const forwarded = req.headers.get('x-forwarded-for')
     if (forwarded) {
         const first = forwarded.split(',')[0]?.trim()
         if (first) return first
-    }
-
-    const realIp = req.headers.get('x-real-ip')
-    if (realIp) return realIp.trim()
-
-    // Next.js 14+ 的 ip 属性
-    if ('ip' in req && typeof (req as NextRequest & { ip?: string }).ip === 'string') {
-        return (req as NextRequest & { ip?: string }).ip!
     }
 
     return '127.0.0.1'

--- a/tests/unit/helpers/rate-limit-ip.test.ts
+++ b/tests/unit/helpers/rate-limit-ip.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { getClientIp } from '@/lib/rate-limit'
+import { NextRequest } from 'next/server'
+
+describe('getClientIp', () => {
+    const createReq = (headers: Record<string, string>, ip?: string) => {
+        const url = 'http://localhost:3000/api/test'
+        return {
+            headers: {
+                get: (name: string) => headers[name.toLowerCase()] || null
+            },
+            ip: ip
+        } as unknown as NextRequest
+    }
+
+    it('should prioritize req.ip if present', () => {
+        const req = createReq({
+            'x-forwarded-for': '1.1.1.1',
+            'x-real-ip': '2.2.2.2'
+        }, '3.3.3.3')
+
+        expect(getClientIp(req)).toBe('3.3.3.3')
+    })
+
+    it('should use x-real-ip if req.ip is missing', () => {
+        const req = createReq({
+            'x-forwarded-for': '1.1.1.1',
+            'x-real-ip': '2.2.2.2'
+        })
+
+        expect(getClientIp(req)).toBe('2.2.2.2')
+    })
+
+    it('should use first IP in x-forwarded-for if req.ip and x-real-ip are missing', () => {
+        const req = createReq({
+            'x-forwarded-for': '1.1.1.1, 8.8.8.8'
+        })
+
+        expect(getClientIp(req)).toBe('1.1.1.1')
+    })
+
+    it('should handle x-forwarded-for with spaces', () => {
+        const req = createReq({
+            'x-forwarded-for': ' 1.1.1.1 , 8.8.8.8'
+        })
+
+        expect(getClientIp(req)).toBe('1.1.1.1')
+    })
+
+    it('should fallback to 127.0.0.1 if no headers or ip property are present', () => {
+        const req = createReq({})
+
+        expect(getClientIp(req)).toBe('127.0.0.1')
+    })
+
+    it('should prefer x-real-ip over x-forwarded-for if both are present but req.ip is missing', () => {
+        const req = createReq({
+            'x-forwarded-for': '1.1.1.1',
+            'x-real-ip': '2.2.2.2'
+        })
+
+        expect(getClientIp(req)).toBe('2.2.2.2')
+    })
+})


### PR DESCRIPTION
Reorder IP extraction logic to prioritize trusted sources. The application previously trusted the user-controllable X-Forwarded-For header as the primary source for IP rate limiting, allowing potential bypass via IP spoofing.

Changes:
- Prioritize req.ip (provided by Next.js/hosting platform).
- Use X-Real-IP (set by trusted internal proxies) as secondary source.
- Fallback to X-Forwarded-For only if more reliable sources are missing.
- Add unit tests for IP extraction logic.