### PR TITLE
fix: add UserPreference fallback for image/video model configs

### DIFF
--- a/src/lib/config-service.ts
+++ b/src/lib/config-service.ts
@@ -155,11 +155,11 @@ export async function getProjectModelConfig(
 
   return {
     analysisModel: extractModelKey(projectData?.analysisModel) || extractModelKey(userPref?.analysisModel) || null,
-    characterModel: extractModelKey(projectData?.characterModel) || null,
-    locationModel: extractModelKey(projectData?.locationModel) || null,
-    storyboardModel: extractModelKey(projectData?.storyboardModel) || null,
-    editModel: extractModelKey(projectData?.editModel) || null,
-    videoModel: extractModelKey(projectData?.videoModel) || null,
+    characterModel: extractModelKey(projectData?.characterModel) || extractModelKey(userPref?.characterModel) || null,
+    locationModel: extractModelKey(projectData?.locationModel) || extractModelKey(userPref?.locationModel) || null,
+    storyboardModel: extractModelKey(projectData?.storyboardModel) || extractModelKey(userPref?.storyboardModel) || null,
+    editModel: extractModelKey(projectData?.editModel) || extractModelKey(userPref?.editModel) || null,
+    videoModel: extractModelKey(projectData?.videoModel) || extractModelKey(userPref?.videoModel) || null,
     audioModel: extractModelKey(projectData?.audioModel) || extractModelKey(userPref?.audioModel) || null,
     videoRatio: projectData?.videoRatio || '16:9',
     artStyle: projectData?.artStyle || null,


### PR DESCRIPTION
## Summary
- `getProjectModelConfig()` only reads `characterModel`, `locationModel`, `storyboardModel`, `editModel`, and `videoModel` from the `NovelPromotionProject` table, with no fallback to `UserPreference`
- This causes "Location model not configured" errors when models are only configured at the user level
- Adds `userPref` fallback for all 5 fields, consistent with how `analysisModel` and `audioModel` already work

## Test plan
- [ ] Set model config only in UserPreference (not project-level)
- [ ] Trigger regenerate location/character/storyboard image
- [ ] Verify no "model not configured" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)